### PR TITLE
CircleCI elasticsearch-oss image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ defaults: &defaults
       - POSTGRES_USER: testName
       - POSTGRES_DB: testDb
       - POSTGRES_PASSWORD: testPass
-    - image: docker.elastic.co/elasticsearch/elasticsearch:6.2.4
+    - image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4
       environment:
       - discovery.type=single-node
 


### PR DESCRIPTION
Reduce license complexity by utilising the OSS derivitave of Elasticsearch.